### PR TITLE
prb: maxJsonLength property exceeded

### DIFF
--- a/src/log4net.ElasticSearch/ExtensionMethods.cs
+++ b/src/log4net.ElasticSearch/ExtensionMethods.cs
@@ -32,7 +32,9 @@ namespace log4net.ElasticSearch
 
         public static string ToJson<T>(this T self)
         {
-            return new JavaScriptSerializer().Serialize(self);
+            JavaScriptSerializer serializer = new JavaScriptSerializer();
+            serializer.MaxJsonLength = Int32.MaxValue;
+            return serializer.Serialize(self);
         }
 
         public static bool Contains(this StringDictionary self, string key)


### PR DESCRIPTION
prb: System.InvalidOperationException occurred - Error during serialization or deserialization using the JSON JavaScriptSerializer. The length of the string exceeds the value set on the maxJsonLength property. 
fix: increase MaxJsonLength

https://stackoverflow.com/questions/46641823/maxjsonlength-exceeded-logging-with-log4net-elasticsearch-appender